### PR TITLE
Add a new rule to make sure function parens are consistent.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
     "comma-spacing": "error",
     "curly": "error",
     "eol-last": "error",
+    "function-paren-newline": ["error", "consistent"],
     "key-spacing": ["error", {"beforeColon": false, "afterColon": true}],
     "keyword-spacing": ["error", {"overrides": {
       "catch": {"after": false},


### PR DESCRIPTION
This means the following 

invalid:
```js

before(async () => {
  }
) // error here
```

valid:
```js
function multiArgs(
  one,
  two,
  three,
  four,
  five,
  six
) {

}
```