### PR TITLE
Add rule for single quotes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = {
     "comma-spacing": "error",
     "curly": "error",
     "eol-last": "error",
-    "function-paren-newline": ["error", "consistent"],
     "key-spacing": ["error", {"beforeColon": false, "afterColon": true}],
     "keyword-spacing": ["error", {"overrides": {
       "catch": {"after": false},

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = {
     "object-shorthand": ["error", "properties"],
     "operator-linebreak": ["error", "after"],
     "prefer-const": "error",
+    "quotes": ["error", "single"],
     "semi": ["error", "always"],
     "semi-spacing": "error",
     "space-before-blocks": "error",


### PR DESCRIPTION
Adds a rule so linter errors on double qoutes.
removes the func-paren rule entirely until we can find a better solution.