### PR TITLE
Remove danglings commas from templates.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es6: true
+  },
+  extends: './index.js'
+};

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 module.exports = {
   env: {
-    es6: true,
+    es6: true
   },
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: 'module',
+    sourceType: 'module'
   },
   rules: {
     'arrow-parens': ['error', 'as-needed'],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Digital Bazaar's eslint rules",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint -c index.js **/*.js"
   },
   "repository": {
     "type": "git",

--- a/templates/.eslintrc.js
+++ b/templates/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    node: true
+  }
+};

--- a/templates/node.js
+++ b/templates/node.js
@@ -1,8 +1,8 @@
 module.exports = {
   env: {
-    node: true,
+    node: true
   },
   extends: [
-    'eslint-config-digitalbazaar',
-  ],
+    'eslint-config-digitalbazaar'
+  ]
 };

--- a/templates/vue.js
+++ b/templates/vue.js
@@ -1,8 +1,8 @@
 module.exports = {
   env: {
-    browser: true,
+    browser: true
   },
   extends: [
-    'eslint-config-digitalbazaar/vue',
-  ],
+    'eslint-config-digitalbazaar/vue'
+  ]
 };

--- a/vue.js
+++ b/vue.js
@@ -1,13 +1,13 @@
 module.exports = {
-  "env": {
-    "browser": true,
+  env: {
+    browser: true
   },
-  "extends": ["./index.js", "plugin:vue/recommended"],
-  "rules": {
-    "vue/mustache-interpolation-spacing": "never",
-    "vue/html-closing-bracket-newline": ["error", {
-      "singleline": "never",
-      "multiline": "never"
+  extends: ['./index.js', 'plugin:vue/recommended'],
+  rules: {
+    'vue/mustache-interpolation-spacing': 'never',
+    'vue/html-closing-bracket-newline': ['error', {
+      singleline: 'never',
+      multiline: 'never'
     }]
   }
 };


### PR DESCRIPTION
1. removes dangling commas from templates and rules (do double check).
2. allows the project to lint itself
3. cleans up remaining lint errors produces by linting itself.