### PR TITLE
Use a more consistent style to turn off errors in vue lint rules.

### DIFF
--- a/vue.js
+++ b/vue.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   extends: ['plugin:vue/recommended'],
   rules: {
-    'vue/mustache-interpolation-spacing': 'never',
+    'vue/mustache-interpolation-spacing': ['error', 'never'],
     'vue/html-closing-bracket-newline': ['error', {
       singleline: 'never',
       multiline: 'never'


### PR DESCRIPTION
This option no longer takes a string it now takes an array like most of the other other rules:

https://eslint.vuejs.org/rules/mustache-interpolation-spacing.html

Weirdly this states this rule's options has not changed since 12/29/2018.
