### PR TITLE
Update eslint dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # eslint-config-digitalbazaar ChangeLog
 
+### Changed
+- Update eslint dependencies:
+  - Update version.
+  - **BREAKING**: Remove from regular dependencies.
+  - Add to devDependencies.
+  - Add to peerDependencies.
+
 ## 2.1.0 - 2020-01-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "url": "https://github.com/digitalbazaar/eslint-config-digitalbazaar/issues"
   },
   "homepage": "https://github.com/digitalbazaar/eslint-config-digitalbazaar#readme",
-  "dependencies": {
-    "eslint": "^5.13.0"
+  "devDependencies": {
+    "eslint": "^6.8.0"
   },
-  "devDependencies": {}
+  "peerDependencies": {
+    "eslint": "5.13.x - 6.x"
+  }
 }


### PR DESCRIPTION
- Update version.
- **BREAKING**: Remove from regular dependencies.
- Add to devDependencies.
- Add to peerDependencies.

Moving eslint to what appears to be the common pattern: not in deps, in devDeps, in peerDeps.  Having just an older 5.x version in regular deps was causing multiple eslint versions to be installed in every package that has updated to 6.x.

This is a breaking change, but our common usage pattern has been to depend on eslint and eslint-config-digitalbazaar.  I'd suggest just making this a minor version bump since it's only a developer visible issue and easily fixed in the few, if any, packages that might break.