### PR TITLE
No cond assignment & no invalid typeOf.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = {
     }],
     'linebreak-style': ['error', 'unix'],
     'max-len': ['error', 80],
+    'no-cond-assign': 'error',
     'no-const-assign': 'error',
     'no-dupe-keys': 'error',
     'no-extra-semi': 'error',
@@ -61,6 +62,7 @@ module.exports = {
     }],
     'space-infix-ops': 'error',
     'space-in-parens': ['error', 'never'],
+    'valid-typeof': 'error',
     yoda: 'error'
   }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -15,8 +15,7 @@ const noConcat = 'a' + 'b';
 
 const r = new RegExp('\\');
 
-/* eslint no-cond-assign: 2 */
-const a = {foo: null}
+const a = {foo: null};
 
 if(a.foo = 'x') {
 
@@ -40,3 +39,5 @@ if('red' === color) {
 if(color === 'red') {
 
 }
+
+typeof color === 'strnig';


### PR DESCRIPTION
Adds 2 new rules:

https://eslint.org/docs/rules/no-cond-assign

https://eslint.org/docs/rules/valid-typeof

which results in:

```js
if(a.foo = 'x') {
  // eslint does not like this
}

const color = 'foo'

// eslint does not like this either
typeof color === 'strnig';
```