### PR TITLE
Add 'no-loss-of-precision': 'error' & tests for it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = {
     'no-dupe-keys': 'error',
     'no-extra-semi': 'error',
     'no-irregular-whitespace': 'error',
+    'no-loss-of-precision': 'error',
     'no-mixed-spaces-and-tabs': 'error',
     'no-multi-spaces': 'error',
     'no-multiple-empty-lines': ['error', {max: 1}],

--- a/test/index.js
+++ b/test/index.js
@@ -41,3 +41,10 @@ if(color === 'red') {
 }
 
 typeof color === 'strnig';
+
+// no-loss-of-precision: "error"
+const precisionTest = {
+  noError: 10,
+  error: 9999999999999999,
+  hexError: 0x2386F26FC0FFFF
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,9 @@
+/**
+ * This module is for testing eslint rules so we have examples
+ * to look at.
+ *
+*/
+
 /* eslint no-unused-vars: 0 */
 
 /* eslint no-implicit-coercion: 2 */
@@ -40,7 +46,10 @@ if(color === 'red') {
 
 }
 
+// this will throw an eslint error
 typeof color === 'strnig';
+// this will not throw an eslint error
+typeof color === 'string';
 
 // no-loss-of-precision: "error"
 const precisionTest = {


### PR DESCRIPTION
Addresses Issue: https://github.com/digitalbazaar/eslint-config-digitalbazaar/issues/42

```js
no-loss-of-precision: "error"
```

Source: https://eslint.org/docs/rules/no-loss-of-precision

> This rule would disallow the use of number literals that immediately lose precision at runtime when converted to a JS Number due to 64-bit floating-point rounding.
> Rule Details
> 
> In JS, Numbers are stored as double-precision floating-point numbers according to the IEEE 754 standard. Because of this, numbers can only retain accuracy up to a certain amount of digits. If the programmer enters additional digits, those digits will be lost in the conversion to the Number type and will result in unexpected behavior.

