### PR TITLE
Define one-var rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # eslint-config-digitalbazaar ChangeLog
 
+### 2.7.0 - TBD
+
+### Added
+- Add rule for `one-var`. Require multiple variable declarations per scope.
+
 ### 2.6.1 - 2020-09-11
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ module.exports = {
     'no-var': 'error',
     'object-curly-spacing': 'error',
     'object-shorthand': ['error', 'properties'],
+    'one-var': ['error', 'never'],
     'operator-linebreak': ['error', 'after'],
     'prefer-const': 'error',
     quotes: ['error', 'single', {allowTemplateLiterals: true}],


### PR DESCRIPTION
Enforces one of the basic rules here: https://github.com/digitalbazaar/bedrock/blob/master/CONTRIBUTING.md#javascript

> Prefer one variable declaration per line, no elaborate indentation, and declare nearest to where variables are used. You may declare simple iterator vars for loops multiple times in the same function, functional-scope notwithstanding.

With this rule:
```
let foo, bar;
```
produces error: `Split 'let' declarations into multiple statements.`

https://eslint.org/docs/rules/one-var
