### PR TITLE
Add rule for dot-notation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # eslint-config-digitalbazaar ChangeLog
 
+### 2.8.0 - TBD
+
+### Added
+- Add rule for `dot-notation`.
+
 ### 2.7.0 - 2021-04-12
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
     'comma-dangle': ['error', 'only-multiline'],
     'comma-spacing': 'error',
     curly: 'error',
+    'dot-notation': 'error',
     'eol-last': 'error',
     'key-spacing': ['error', {beforeColon: false, afterColon: true}],
     'keyword-spacing': ['error', {overrides: {

--- a/test/index.js
+++ b/test/index.js
@@ -70,3 +70,6 @@ jsonProps['bar'] = 2;
 
 // error
 jsonProps['snake_case'] = 5;
+
+// does not error if prop contains @
+jsonProps['@context'] = 'did:context:foo';

--- a/test/index.js
+++ b/test/index.js
@@ -59,11 +59,14 @@ const precisionTest = {
 };
 
 // OK
-const foo = {};
-foo.bar = 1;
+const jsonProps = {};
+jsonProps.bar = 1;
 // this is common when dealing with bedrock configs
 // and this does **not** produce an error
-foo['some-baz'] = 8;
+jsonProps['some-baz'] = 8;
 
 // error
-foo['bar'] = 2;
+jsonProps['bar'] = 2;
+
+// error
+jsonProps['snake_case'] = 5;

--- a/test/index.js
+++ b/test/index.js
@@ -57,3 +57,13 @@ const precisionTest = {
   error: 9999999999999999,
   hexError: 0x2386F26FC0FFFF
 };
+
+// OK
+const foo = {};
+foo.bar = 1;
+// this is common when dealing with bedrock configs
+// and this does **not** produce an error
+foo['some-baz'] = 8;
+
+// error
+foo['bar'] = 2;


### PR DESCRIPTION
Addresses: https://github.com/digitalbazaar/eslint-config-digitalbazaar/issues/46

```
// OK
const foo = {};
foo.bar = 1;
// this is common when dealing with bedrock configs and this does **not** produce an error
foo['some-baz'] = 8;

// error
foo['bar'] = 2;
```

https://eslint.org/docs/rules/dot-notation