### PR TITLE
Add override to hand *.cjs and *.mjs files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # eslint-config-digitalbazaar ChangeLog
 
+### 2.9.0 -
+
+### Added
+- Add override to handle `*.cjs` and `*.mjs` files by default.
+
 ### 2.8.0 - 2021-04-12
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module'
   },
+  overrides: [{
+    files: ['*.cjs', '*.mjs'],
+  }],
   rules: {
     'arrow-parens': ['error', 'as-needed'],
     'arrow-spacing': 'error',


### PR DESCRIPTION
I'm not entirely sure this is the correct way to do this but it seemed to work in my limited test.  Was surprised it wasn't happening by default since node uses this extensions now.