### PR TITLE
Add module preset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Use eslint-plugin-eslint-plugin to self check.
+- Add module preset.
 
 ### Changed
 - Use "test" target to show file errors. This should be improved to do proper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # eslint-config-digitalbazaar ChangeLog
 
+### 2.9.0 - 2022-xx-xx
+
 ### Added
 - Use eslint-plugin-eslint-plugin to self check.
 - Add module preset.

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ The rules do not depend on each other and are composable:
 module.exports = {
   extends: [
     'digitalbazaar',
-    'digitalbazaar/module'
     'digitalbazaar/jsdoc',
+    'digitalbazaar/module'
     'digitalbazaar/vue'
   ] // all 4 rule sets in one file using shorthand.
 }

--- a/README.md
+++ b/README.md
@@ -63,14 +63,24 @@ module.exports = {
 }
 ```
 
+To use ES module code rather than CommonJS, load the 'module' rules.
+
+Example .eslintrc.js ESM setup:
+```js
+module.exports = {
+  extends: ['digitalbazaar/module'] // only the module rules and any rules in parent dirs
+}
+```
+
 The rules do not depend on each other and are composable:
 ```js
 module.exports = {
   extends: [
     'digitalbazaar',
     'digitalbazaar/vue',
-    'digitalbazaar/jsdoc'
-  ] // all 3 rule sets in one file using shorthand.
+    'digitalbazaar/jsdoc',
+    'digitalbazaar/module'
+  ] // all 4 rule sets in one file using shorthand.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,20 +40,6 @@ module.exports = {
 }
 ```
 
-### Vue
-
-To use the Vue rules you will need to install [`eslint-plugin-vue`](https://eslint.vuejs.org/):
-```
-npm i -D eslint-plugin-vue
-```
-
-Example .eslintrc.js Vue setup:
-```js
-module.exports = {
-  extends: ['digitalbazaar/vue'] // only the vue rules and any rules in parent dirs
-}
-```
-
 ### JSDoc
 
 To use the JSDoc rules you will need to install [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc):
@@ -81,6 +67,22 @@ module.exports = {
   extends: ['digitalbazaar/module'] // only the module rules and any rules in parent dirs
 }
 ```
+
+### Vue
+
+To use the Vue rules you will need to install [`eslint-plugin-vue`](https://eslint.vuejs.org/):
+```
+npm i -D eslint-plugin-vue
+```
+
+Example .eslintrc.js Vue setup:
+```js
+module.exports = {
+  extends: ['digitalbazaar/vue'] // only the vue rules and any rules in parent dirs
+}
+```
+
+### Composition
 
 The rules do not depend on each other and are composable:
 ```js

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 This package provides eslint rules used by Digital Bazaar as a set of extendable shared configs.
 
-There are 3 rule sets:
-1. eslint-config-digitalbazaar -  Base rules for both node and the browser.
-2. eslint-config-digitalbazaar/vue -  Rules for Vue projects and browser only.
-3. eslint-config-digitalbazaar/jsdoc -  Rules for JSDoc for both node and the browser.
+There are 4 rule sets:
+1. `eslint-config-digitalbazaar`: Base rules for both node and the browser.
+2. `eslint-config-digitalbazaar/jsdoc`: Rules for JSDoc for both node and the browser.
+3. `eslint-config-digitalbazaar/module`: Rules for modules for both node and the browser.
+4. `eslint-config-digitalbazaar/vue`: Rules for Vue projects and browser only.
 
 ## Installation
 
@@ -39,7 +40,9 @@ module.exports = {
 }
 ```
 
-To use the Vue rules you will need to install the vue-eslint-plugin
+### Vue
+
+To use the Vue rules you will need to install [`eslint-plugin-vue`](https://eslint.vuejs.org/):
 ```
 npm i -D eslint-plugin-vue
 ```
@@ -51,7 +54,9 @@ module.exports = {
 }
 ```
 
-To use the JSDoc rules you will need to install the eslint-plugin-jsdoc
+### JSDoc
+
+To use the JSDoc rules you will need to install [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc):
 ```
 npm i -D eslint-plugin-jsdoc
 ```
@@ -63,7 +68,12 @@ module.exports = {
 }
 ```
 
-To use ES module code rather than CommonJS, load the 'module' rules.
+### Modules
+
+To use ES module code rather than CommonJS, you will need to install [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn):
+```
+npm i -D eslint-plugin-unicorn
+```
 
 Example .eslintrc.js ESM setup:
 ```js
@@ -77,9 +87,9 @@ The rules do not depend on each other and are composable:
 module.exports = {
   extends: [
     'digitalbazaar',
-    'digitalbazaar/vue',
-    'digitalbazaar/jsdoc',
     'digitalbazaar/module'
+    'digitalbazaar/jsdoc',
+    'digitalbazaar/vue'
   ] // all 4 rule sets in one file using shorthand.
 }
 ```

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ module.exports = {
 
 ### Modules
 
-To use ES module code rather than CommonJS, you will need to install [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn):
+To use ES module code rather than CommonJS, you will need to install [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn) (<=40 needed until this package updates to eslint 8 support):
 ```
-npm i -D eslint-plugin-unicorn
+npm i -D eslint-plugin-unicorn@40
 ```
 
 Example .eslintrc.js ESM setup:

--- a/module.js
+++ b/module.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    es2022: true
+    es2020: true
   },
   parserOptions: {
     ecmaVersion: 'latest',

--- a/module.js
+++ b/module.js
@@ -1,0 +1,15 @@
+module.exports = {
+  env: {
+    es6: true
+  },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: [
+    'unicorn'
+  ],
+  rules: {
+    'unicorn/prefer-module': 'error'
+  }
+};

--- a/module.js
+++ b/module.js
@@ -3,7 +3,6 @@ module.exports = {
     es2020: true
   },
   parserOptions: {
-    ecmaVersion: 'latest',
     sourceType: 'module'
   },
   plugins: [

--- a/module.js
+++ b/module.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    es6: true
+    es2022: true
   },
   parserOptions: {
     ecmaVersion: 'latest',

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   },
   "peerDependencies": {
     "eslint": "^7.1.0"
+  },
+  "dependencies": {
+    "eslint-plugin-unicorn": "^39.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,5 @@
   },
   "peerDependencies": {
     "eslint": "^7.1.0"
-  },
-  "dependencies": {
-    "eslint-plugin-unicorn": "^39.0.0"
   }
 }


### PR DESCRIPTION
This adds a "module" preset, for use with any ES Modules.
- It pulls in [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) just for their [`prefer-module`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-module.md) rules. I'm not sure if this adds too much weight, but it was easier for now than trying to replicate just the module parts.
- The `parserOptions.ecmaVersion: 'latest'` was copied from somewhere and I suspect that could just be a version or year to avoid allow too new syntax.  I'm not sure what value is appropriate here.
- I suspect we may want some local rule adjustments for our projects which is why this wrapper preset was made instead of just using `prefer-module` directly in all of our modules.