### PR TITLE
Set env 2022 update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # eslint-config-digitalbazaar ChangeLog
 
+### 3.0.0 - 2022-xx-xx
+
+### Changed
+- **BREAKING**: Update to `eslint@8`.
+- Use `es2022` environment. Automatically sets `ecmaVersion` to `13` (2022).
+- Disable `jsdoc/check-examples` until
+  [eslint 8 related issue](https://github.com/eslint/eslint/issues/14745) is fixed.
+
 ### 2.9.0 - 2022-04-22
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ module.exports = {
     es2022: true
   },
   parserOptions: {
-    ecmaVersion: 'latest',
     sourceType: 'module'
   },
   rules: {

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -1,7 +1,9 @@
 module.exports = {
   plugins: ['jsdoc'],
   rules: {
-    'jsdoc/check-examples': 1,
+    // Enable once eslint 8 related issue is fixed:
+    // https://github.com/eslint/eslint/issues/14745
+    //'jsdoc/check-examples': 1,
     'jsdoc/check-param-names': 1,
     'jsdoc/check-tag-names': 1,
     'jsdoc/check-types': 1,

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "homepage": "https://github.com/digitalbazaar/eslint-config-digitalbazaar#readme",
   "devDependencies": {
-    "eslint": "^8.12.0",
-    "eslint-plugin-eslint-plugin": "^4.0.3"
+    "eslint": "^8.14.0",
+    "eslint-plugin-eslint-plugin": "^4.1.0"
   },
   "peerDependencies": {
-    "eslint": "^8.12.0"
+    "eslint": "^8.14.0"
   }
 }


### PR DESCRIPTION
- Propose disabling `jsdoc/check-examples` until upstream issues are fixed.
- It seems `ecmaVersion` is redundant when `env.es2022` is set.
- Update dependencies.
- Add changelog.