### PR TITLE
Add sort imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # eslint-config-digitalbazaar ChangeLog
+### 4.1.0 -
+
+### Added
+- Added rules for [`sort-imports`](https://eslint.org/docs/rules/sort-imports)
 
 ### 3.0.0 - 2022-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # eslint-config-digitalbazaar ChangeLog
-### 4.1.0 -
+### 4.0.0 -
 
 ### Added
 - Added rules for [`sort-imports`](https://eslint.org/docs/rules/sort-imports)

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = {
     'quote-props': ['error', 'as-needed'],
     semi: ['error', 'always'],
     'semi-spacing': 'error',
+    'sort-imports': 'error',
     'space-before-blocks': 'error',
     'space-before-function-paren': ['error', {
       anonymous: 'never',

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = {
     'quote-props': ['error', 'as-needed'],
     semi: ['error', 'always'],
     'semi-spacing': 'error',
-    'sort-imports': 'error',
+    'sort-imports': ['error', {ignoreCase: true}],
     'space-before-blocks': 'error',
     'space-before-function-paren': ['error', {
       anonymous: 'never',

--- a/index.js
+++ b/index.js
@@ -57,7 +57,11 @@ module.exports = {
     'quote-props': ['error', 'as-needed'],
     semi: ['error', 'always'],
     'semi-spacing': 'error',
-    'sort-imports': ['error', {ignoreCase: true}],
+    'sort-imports': ['error', {
+      allowSeparatedGroups: true,
+      ignoreCase: true,
+      memberSyntaxSortOrder: ['all', 'multiple', 'single', 'none']
+    }],
     'space-before-blocks': 'error',
     'space-before-function-paren': ['error', {
       anonymous: 'never',

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,50 @@
  *
 */
 
+// demo of the sort imports rules
+// incorrect all
+import * as bAll from 'b.js';
+import * as aAll from 'a.js';
+
+// correct all
+import * as aaAll from 'a.js';
+import * as bbAll from 'b.js';
+
+// incorrect multiple
+import {zed, rat, girl} from 'baboon2000.js';
+
+// correct multiple
+import {girl2, rat2, zed2} from 'baboon2000.js';
+
+// incorrect single
+import {default1} from 'defaulter';
+import aDefault1 from 'adefaulter';
+
+// correct single
+import aDefault2 from 'adefaulter';
+import {default2} from 'defaulter';
+
+// imports with no members must go last
+import 'no-members';
+import * as baboon1 from 'baboon-lib-1';
+
+// imports with no members must go last
+import * as baboon2 from 'baboon-lib-1';
+import 'no-members';
+
+/*
+ * * as all goes first
+ * import {multiple, members} goes second
+ * import singleMember goes third
+ * import {singleMember goes third too
+ * import 'no-members' goes last
+ */
+import * as baboon3 from 'babbon-lib-3';
+import {multi1, multi2, multi3} from 'multi-x-3';
+import single3 from 'has-default-export';
+import {single4} from 'has-single-named-export';
+import 'no-export';
+
 /* eslint no-unused-vars: 0 */
 
 /* eslint no-implicit-coercion: 2 */

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,7 @@ import * as baboon2 from 'baboon-lib-1';
 import 'no-members';
 
 /*
- * * as all goes first
+ * import * as all goes first
  * import {multiple, members} goes second
  * import singleMember goes third
  * import {singleMember goes third too

--- a/test/index.js
+++ b/test/index.js
@@ -39,7 +39,7 @@ import 'no-members';
  * import * as all goes first
  * import {multiple, members} goes second
  * import singleMember goes third
- * import {singleMember goes third too
+ * import {singleMember} goes third
  * import 'no-members' goes last
  */
 import * as baboon3 from 'babbon-lib-3';


### PR DESCRIPTION
new rule:

https://eslint.org/docs/rules/sort-imports

1. Sorts by imported method name over module path
2. I turned on `ignoreCase: true` this is because Capitalized Class names would then trump other imports.

Example 1:
```js
// this shows that member name is less important than module path 
import {a} from 'z.js'
import {b} from 'y.hs'
```

Example 2:
```js
// this shows that a goes before Z even if Z is capitalized
import a from 'b.js';
import {ZcapClient} from '@digitalbazaar/ezcap'; 
```

`sort-imports` sorts first by import type and then secondly by alphabetized member name.
We're using this sort order:

1. **all** - `import * as jsonld from 'jsonld';`
2. **multiple** - `import {a, b} from './foo.js';`
3. **single** - `import a from 'z.js';`
4. **{single}** - `import {bar} from 'foo.js';`
5. **none** - `import 'bedrock-test';`

There for our imports would look like this:

```js
// all alphabetized by member name
import * as allOfIt from 'old-lib'
import * as oneBigImport from 'big-import';
// multiple with alphabetized member names
import {a, b, c} from 'multi-es6';
// single import
import {oneThing} from './src/local.js';
import zed from 'zed';
// none
import 'no-members';
```