### PR TITLE
Revert prefer-node-protocol rule addition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # eslint-config-digitalbazaar ChangeLog
 
-### 4.0.0 - 2022-xx-xx
-
-### Added
-- **BREAKING**: Use
-  [`unicorn/prefer-node-protocol`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md)
-  in 'module' rules.
-
 ### 3.0.0 - 2022-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -97,3 +97,25 @@ module.exports = {
 ```
 
 The rules can also be used together via [cascade configuration](https://eslint.org/docs/user-guide/configuring).
+
+## Other Rules
+
+Other rules that are not included above but can be useful:
+
+### `unicorn/prefer-node-protocol`
+
+Use `node:module` style for Node.js modules.
+
+See [`unicorn/prefer-node-protocol`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md).
+
+Requires:
+```
+npm i -D eslint-plugin-unicorn
+```
+
+Rules:
+```js
+  rules: {
+    'unicorn/prefer-node-protocol': 'error'
+  }
+```

--- a/module.js
+++ b/module.js
@@ -9,7 +9,6 @@ module.exports = {
     'unicorn'
   ],
   rules: {
-    'unicorn/prefer-module': 'error',
-    'unicorn/prefer-node-protocol': 'error'
+    'unicorn/prefer-module': 'error'
   }
 };


### PR DESCRIPTION
- Reverts 3640b9e3a6d1427ab6ca7b4412ea9f58658369c4 / https://github.com/digitalbazaar/eslint-config-digitalbazaar/pull/59.
- Add as a note in README since rule is useful.