### PR TITLE
Use eslint plugin import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 ### Added
 - Add `digitalbazaar/vue3` preset for Vue 3. Use `digitalbazaar/vue` for Vue 2.
 
-### Added
-- Add `digitalbazaar/vue3` preset for Vue 3. Use `digitalbazaar/vue` for Vue 2.
-
 ### Changed
 - Template cleanups.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Add `digitalbazaar/vue3` preset for Vue 3. Use `digitalbazaar/vue` for Vue 2.
 
+### Added
+- Add `digitalbazaar/vue3` preset for Vue 3. Use `digitalbazaar/vue` for Vue 2.
+
 ### Changed
 - Template cleanups.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ There are 4 rule sets:
 1. `eslint-config-digitalbazaar`: Base rules for both node and the browser.
 2. `eslint-config-digitalbazaar/jsdoc`: Rules for JSDoc for both node and the browser.
 3. `eslint-config-digitalbazaar/module`: Rules for modules for both node and the browser.
-4. `eslint-config-digitalbazaar/vue`: Rules for Vue 2 projects and browser only.
-5. `eslint-config-digitalbazaar/vue3`: Rules for Vue 3 projects and browser only.
+4. `eslint-config-digitalbazaar/vue`: Rules for Vue projects and browser only.
 
 ## Installation
 
@@ -17,13 +16,13 @@ npm i -D eslint
 npm i -D eslint-config-digitalbazaar
 ```
 
-To start an eslint config file (choose .eslintrc.js):
+To start an eslint config file (choose .eslintrc.cjs):
 ```
 npx eslint --init
 ```
 or rename a template from the templates dir
 ```
-cp node_modules/eslint-config-digitalbazaar/templates/node.js ./.eslintrc.js
+cp node_modules/eslint-config-digitalbazaar/templates/node.js ./.eslintrc.cjs
 ```
 
 ## Usage
@@ -33,12 +32,11 @@ or using the full module name `eslint-config-digitalbazaar`.
 
 Eslint's documentation on [shareable configs](https://eslint.org/docs/developer-guide/shareable-configs) can be found here.
 
-Example .eslintrc.js root setup:
+Example .eslintrc.cjs root setup:
 ```js
 module.exports = {
   root: true,
-  // using full module name
-  extends: ['eslint-config-digitalbazaar']
+  extends: ['eslint-config-digitalbazaar'] // using full module name
 }
 ```
 
@@ -49,11 +47,10 @@ To use the JSDoc rules you will need to install [`eslint-plugin-jsdoc`](https://
 npm i -D eslint-plugin-jsdoc
 ```
 
-Example .eslintrc.js JSDoc setup:
+Example .eslintrc.cjs JSDoc setup:
 ```js
 module.exports = {
-  // only the JSDoc rules and any rules in parent dirs
-  extends: ['digitalbazaar/jsdoc']
+  extends: ['digitalbazaar/jsdoc'] // only the JSDoc rules and any rules in parent dirs
 }
 ```
 
@@ -64,49 +61,39 @@ To use ES module code rather than CommonJS, you will need to install [`eslint-pl
 npm i -D eslint-plugin-unicorn
 ```
 
-Example .eslintrc.js ESM setup:
+Example .eslintrc.cjs ESM setup:
 ```js
 module.exports = {
-  // only the module rules and any rules in parent dirs
-  extends: ['digitalbazaar/module']
+  extends: ['digitalbazaar/module'] // only the module rules and any rules in parent dirs
 }
 ```
 
-### Vue 2
+To use the es6 module import rules you will need to install [`eslint-plugin-import`](https://www.npmjs.com/package/eslint-plugin-import):
+```
+npm i -D eslint-plugin-import
+```
+Example .eslintrc.cjs ESM setup:
+```js
+module.exports = {
+  extends: ['digitalbazaar/import'] // only the import rules and any rules in parent dirs
+}
+```
 
-To use the Vue 2 rules you will need to install [`eslint-plugin-vue`](https://eslint.vuejs.org/):
+
+
+### Vue
+
+To use the Vue rules you will need to install [`eslint-plugin-vue`](https://eslint.vuejs.org/):
 ```
 npm i -D eslint-plugin-vue
 ```
 
-Example .eslintrc.js Vue setup:
+Example .eslintrc.cjs Vue setup:
 ```js
 module.exports = {
-  // only the vue rules and any rules in parent dirs
-  extends: ['digitalbazaar/vue']
+  extends: ['digitalbazaar/vue'] // only the vue rules and any rules in parent dirs
 }
 ```
-
-For command line use you may need to [explicitly enable linting `.vue`
-files](https://eslint.vuejs.org/user-guide/#running-eslint-from-the-command-line).
-
-### Vue 3
-
-To use the Vue 3 rules you will need to install [`eslint-plugin-vue`](https://eslint.vuejs.org/):
-```
-npm i -D eslint-plugin-vue
-```
-
-Example .eslintrc.js Vue setup:
-```js
-module.exports = {
-  // only the vue3 rules and any rules in parent dirs
-  extends: ['digitalbazaar/vue3']
-}
-```
-
-For command line use you may need to [explicitly enable linting `.vue`
-files](https://eslint.vuejs.org/user-guide/#running-eslint-from-the-command-line).
 
 ### Composition
 
@@ -117,8 +104,8 @@ module.exports = {
     'digitalbazaar',
     'digitalbazaar/jsdoc',
     'digitalbazaar/module'
-    'digitalbazaar/vue3'
-  ] // 4 rule sets in one file using shorthand.
+    'digitalbazaar/vue'
+  ] // all 4 rule sets in one file using shorthand.
 }
 ```
 

--- a/import.js
+++ b/import.js
@@ -31,7 +31,7 @@ module.exports = {
     'import/no-deprecated': 'error',
     // warns if a dep is not in the package.json
     'import/no-extraneous-dependencies': 'error',
-    // what is says
+    // disallows exporting members with let & var
     // FIXME: there could be edge cases where we do
     // need mutable exports
     'import/no-mutable-exports': 'error',

--- a/import.js
+++ b/import.js
@@ -10,10 +10,6 @@ module.exports = {
     'import'
   ],
   rules: {
-    // if the file path for an import can't be resolved locally error
-    // this rule ignores namespaced npm packages
-    // (this seems to be broken in the plugin)
-    'import/no-unresolved': ['error', {ignore: ['^@']}],
     // Verifies that all named imports are part of the set of named
     // exports in the imported module.
     'import/named': 'error',

--- a/import.js
+++ b/import.js
@@ -11,8 +11,9 @@ module.exports = {
   ],
   rules: {
     // if the file path for an import can't be resolved locally error
-    // FIXME: use of webpack aliases might cause issues with this
-    'import/no-unresolved': 'error',
+    // this rule ignores namespaced npm packages
+    // (this seems to be broken in the plugin)
+    'import/no-unresolved': ['error', {ignore: ['^@']}],
     // Verifies that all named imports are part of the set of named
     // exports in the imported module.
     'import/named': 'error',

--- a/import.js
+++ b/import.js
@@ -1,0 +1,41 @@
+module.exports = {
+  env: {
+    es2020: true
+  },
+  parserOptions: {
+    sourceType: 'module'
+  },
+  plugins: [
+    // https://github.com/import-js/eslint-plugin-import
+    'import'
+  ],
+  rules: {
+    // if the file path for an import can't be resolved locally error
+    // FIXME: use of webpack aliases might cause issues with this
+    'import/no-unresolved': 'error',
+    // Verifies that all named imports are part of the set of named
+    // exports in the imported module.
+    'import/named': 'error',
+    // If a default import is requested, this rule will report if
+    // there is no default export in the imported module.
+    'import/default': 'error',
+    // throws if a namespace like `import * as all` is used and
+    // `all.foo` is not exported
+    'import/namespace': 'error',
+    // throws if a module imports itself
+    'import/no-self-import': 'error',
+    // Reports funny business with exports, like repeated exports
+    // of names or defaults.
+    'import/export': 'error',
+    // warns if an imported member if marked @deprecated
+    'import/no-deprecated': 'error',
+    // warns if a dep is not in the package.json
+    'import/no-extraneous-dependencies': 'error',
+    // what is says
+    // FIXME: there could be edge cases where we do
+    // need mutable exports
+    'import/no-mutable-exports': 'error',
+    // throw if you import something more than once in a file/module
+    'import/no-duplicates': 'error'
+  }
+};

--- a/import.js
+++ b/import.js
@@ -33,9 +33,6 @@ module.exports = {
     // warns if a dep is not in the package.json
     'import/no-extraneous-dependencies': 'error',
     // disallows exporting members with let & var
-    // FIXME: there could be edge cases where we do
-    // need mutable exports
-    'import/no-mutable-exports': 'error',
     // throw if you import something more than once in a file/module
     'import/no-duplicates': 'error'
   }

--- a/test/imports/.eslintrc.cjs
+++ b/test/imports/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  env: {
+    es6: true
+  },
+  extends: [
+    '../../import.js'
+  ]
+};

--- a/test/imports/default.js
+++ b/test/imports/default.js
@@ -1,0 +1,3 @@
+export default function d() {
+  console.log('d!!');
+}

--- a/test/imports/duplicate.js
+++ b/test/imports/duplicate.js
@@ -1,0 +1,2 @@
+export const duplicate = 'exported twice';
+export {duplicate};

--- a/test/imports/duplicateDefault.js
+++ b/test/imports/duplicateDefault.js
@@ -1,0 +1,8 @@
+export default function d1() {
+
+}
+
+// throws duplicate export
+export default function d2() {
+
+}

--- a/test/imports/duplicateImport.js
+++ b/test/imports/duplicateImport.js
@@ -1,0 +1,4 @@
+// these are imported in separate import statements
+// to show the no duplicate rule
+export const member1 = 'member1';
+export const member2 = 'member2';

--- a/test/imports/index.js
+++ b/test/imports/index.js
@@ -22,14 +22,5 @@ import default1 from './noDefault.js';
 
 // this just gets around linter errors with unused vars
 export const used = {
-  d, unresolved, found
+  d, unresolved, found,
 };
-
-export default function d1() {
-
-}
-
-// throws duplicate export
-export default function d2() {
-
-}

--- a/test/imports/index.js
+++ b/test/imports/index.js
@@ -1,0 +1,35 @@
+import d from './default.js';
+
+// this does not count as a duplicate import
+// this might be a bug in the plugin
+import * as b from './default.js';
+
+// throws namespace error
+b.d();
+
+// import not found
+// also throws no duplicates
+import {notFound1} from './default.js'; 
+
+// throws because notFound is not exported
+import {found, notFound} from './notExported.js';
+
+// throws unresolved
+import unresolved from './unresolved.js';
+
+// throws no default export
+import default1 from './noDefault.js';
+
+// this just gets around linter errors with unused vars
+export const used = {
+  d, unresolved, found
+};
+
+export default function d1() {
+
+}
+
+// throws duplicate export
+export default function d2() {
+
+}

--- a/test/imports/index.js
+++ b/test/imports/index.js
@@ -1,3 +1,4 @@
+// successfully imports a default with no errors
 import d from './default.js';
 
 // this does not count as a duplicate import
@@ -7,9 +8,8 @@ import * as b from './default.js';
 // throws namespace error
 b.d();
 
-// import not found
-// also throws no duplicates
-import {notFound1} from './default.js'; 
+// throws a parse error from the duplicate export
+import {duplicate} from './duplicate.js';
 
 // throws because notFound is not exported
 import {found, notFound} from './notExported.js';
@@ -20,7 +20,13 @@ import unresolved from './unresolved.js';
 // throws no default export
 import default1 from './noDefault.js';
 
+// throws because of duplicate import
+// useful for catching cases where you might have
+// duplicate imports of the same package with different bindings/members
+import {member1} from './duplicateImport.js';
+import {member2} from './duplicateImport.js';
+
 // this just gets around linter errors with unused vars
 export const used = {
-  d, unresolved, found,
+  d, unresolved, found, duplicate, member1, member2
 };

--- a/test/imports/mutable.js
+++ b/test/imports/mutable.js
@@ -1,0 +1,2 @@
+export let v = true;
+v = false;

--- a/test/imports/noDefault.js
+++ b/test/imports/noDefault.js
@@ -1,0 +1,3 @@
+export function notDefault() {
+
+}

--- a/test/imports/notExported.js
+++ b/test/imports/notExported.js
@@ -1,0 +1,8 @@
+export function found() {
+
+}
+
+// this is not exported and causes an error
+function notFound() {
+
+}

--- a/test/imports/package.json
+++ b/test/imports/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "imports",
+  "version": "1.0.0",
+  "description": "For use testing es6 import related linting rules.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "eslint-plugin-import": "^2.26.0"
+  }
+}


### PR DESCRIPTION
- https://github.com/digitalbazaar/eslint-config-digitalbazaar/issues/38
- https://github.com/import-js/eslint-plugin-import
- https://www.npmjs.com/package/eslint-plugin-import

These are the gains from using this plugin:
```js
  rules: {
    // if the file path for an import can't be resolved locally error
    // FIXME: use of webpack aliases might cause issues with this
    'import/no-unresolved': 'error',
    // Verifies that all named imports are part of the set of named
    // exports in the imported module.
    'import/named': 'error',
    // If a default import is requested, this rule will report if
    // there is no default export in the imported module.
    'import/default': 'error',
    // throws if a namespace like `import * as all` is used and
    // `all.foo` is not exported
    'import/namespace': 'error',
    // throws if a module imports itself
    'import/no-self-import': 'error',
    // Reports funny business with exports, like repeated exports
    // of names or defaults.
    'import/export': 'error',
    // warns if an imported member if marked @deprecated
    'import/no-deprecated': 'error',
    // warns if a dep is not in the package.json
    'import/no-extraneous-dependencies': 'error',
    // disallows exporting members with let & var
    // FIXME: there could be edge cases where we do
    // need mutable exports
    'import/no-mutable-exports': 'error',
    // throw if you import something more than once in a file/module
    'import/no-duplicates': 'error'
  }
```

Notes:

1. I have observed this rule working not as intended: `import/no-extraneous-dependencies` (it seems to be a bit flaky)
3. We might want to move the `sort-order` to the `modules` rules
4. We might want to move these rules to the `modules` rules & update the README.

Note: this plugin speeds up refactoring to use `es6` `import/export` statements. It primarily does this, but telling you when you refactor a require to an import if the members you're importing are still there or if there is a default export etc.