### PR TITLE
Update for eslint-plugin-jsdoc >=42.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # eslint-config-digitalbazaar ChangeLog
 
+### 5.0.0 - 2023-xx-xx
+
+### Changed
+- **BREAKING**: Update for `eslint-plugin-jsdoc@42`.
+  - `jsdoc/newline-after-description` changed to `jsdoc/tag-lines` rule.
+  - `eslint-plugin-jsdoc` >= 42 now required to support newer `tag-lines`
+    options.
+
 ### 4.2.0 - 2022-11-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - `jsdoc/newline-after-description` changed to `jsdoc/tag-lines` rule.
   - `eslint-plugin-jsdoc` >= 42 now required to support newer `tag-lines`
     options.
+  - Add optional peer dependency version on `eslint-plugin-jsdoc@42`.
 
 ### 4.2.0 - 2022-11-28
 

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -7,7 +7,7 @@ module.exports = {
     'jsdoc/check-param-names': 1,
     'jsdoc/check-tag-names': 1,
     'jsdoc/check-types': 1,
-    'jsdoc/newline-after-description': 1,
+    'jsdoc/tag-lines': ['error', 'any', {startLines: 1}],
     'jsdoc/no-undefined-types': 1,
     'jsdoc/require-description': 0,
     'jsdoc/require-description-complete-sentence': 1,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
     "eslint-plugin-eslint-plugin": "^4.1.0"
   },
   "peerDependencies": {
-    "eslint": "^8.14.0"
+    "eslint": "^8.14.0",
+    "eslint-plugin-jsdoc": "^42.0.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-jsdoc": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
`jsdoc/newline-after-description` was removed from `eslint-plugin-jsdoc@42`.
https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v42.0.0

- Switching to `jsdoc/tag-lines` that I think is equivalent to the previous behavior.  This is not widely tested yet.
- Adding an optional peer dep version on `eslint-plugin-jsdoc` to get updated `tag-lines` support.  This requires newer npm.  Untested, basing off of docs.