### PR TITLE
Make linebreak-style platform specific

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,10 @@ module.exports = {
       },
       CallExpression: {arguments: 1}
     }],
-    'linebreak-style': ['error', 'unix'],
+    'linebreak-style': [
+      'error',
+      (process.platform === 'win32' ? 'windows' : 'unix')
+    ],
     'max-len': ['error', 80],
     'no-cond-assign': 'error',
     'no-const-assign': 'error',


### PR DESCRIPTION
Committed style should still be `unix` as `git config core.autocrlf` is best practice on Windows.

This makes a massive difference for developers using Windows (like myself). Without that being conditional, eslint is essentially unusable. I've been setting it manually, but that's adding undue tedium...and not fixing it for others in this situation, so hopefully this PR helps more that me. 😁 

Cheers!
🎩 