### PR TITLE
Ignore SPDX ID line lengths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # eslint-config-digitalbazaar ChangeLog
 
+### 5.1.0 - 2024-05-xx
+
+### Changed
+- Ingore `SPDX-License-Identifier` comment lengths. The spec requires one line
+  which can be long when using multiple custom ids.
+
 ### 5.0.1 - 2023-05-19
 
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -31,7 +31,10 @@ module.exports = {
       CallExpression: {arguments: 1}
     }],
     'linebreak-style': ['error', 'unix'],
-    'max-len': ['error', 80],
+    'max-len': ['error', {
+      code: 80,
+      ignorePattern: '\\* SPDX-License-Identifier: '
+    }],
     'no-cond-assign': 'error',
     'no-const-assign': 'error',
     'no-dupe-keys': 'error',


### PR DESCRIPTION
First surfaced by @davidlehn in https://github.com/w3c/vc-data-model-2.0-test-suite/pull/65#discussion_r1578074793