### PR TITLE
Add `ignoreUrls: true` to `max-len` rule.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ module.exports = {
     'linebreak-style': ['error', 'unix'],
     'max-len': ['error', {
       code: 80,
-      ignorePattern: '\\* SPDX-License-Identifier: '
+      ignorePattern: '\\* SPDX-License-Identifier: ',
+      ignoreUrls: true
     }],
     'no-cond-assign': 'error',
     'no-const-assign': 'error',


### PR DESCRIPTION
Long URLs are increasingly common in our test suite code since we are using text selection fragments to connect to specific highlights in specifications.