### PR TITLE
Use eslint 10.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,13 +10,13 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [26.x]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
@@ -27,13 +27,13 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [26.x]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @digitalbazaar/eslint-config ChangeLog
 
+### 9.0.0 - 2026-xx-xx
+
+### Changed
+- **BREAKING**: Update dependencies:
+  - `eslint@10`
+  - `@eslint/js@10`
+  - `eslint-plugin-jsdoc@63`
+  - `eslint-plugin-unicorn@67`
+- Update minor and dev dependencies.
+
+### Removed
+- **BREAKING**: `eslint-plugin-import` support and testing temporarily
+  disabled.
+  - Disabled due to lack of support for eslint 10. Will be re-enabled when
+    possible.
+  - Workaround is to continue using v8 of this config package.
+
 ### 8.0.1 - 2026-02-09
 
 ### Fixed

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,12 +1,14 @@
 import eslintPlugin from 'eslint-plugin-eslint-plugin';
-import importConfig from './configs/import.js';
+// disabled until eslint-plugin-import supports eslint 10
+//import importConfig from './configs/import.js';
 import nodeConfig from './configs/node-recommended.js';
 
 export default [
   eslintPlugin.configs.recommended,
-  ...nodeConfig,
-  {
-    files: ['test/import/*.js'],
-    ...importConfig
-  }
+  ...nodeConfig
+  // disabled until eslint-plugin-import supports eslint 10
+  //{
+  //  files: ['test/import/*.js'],
+  //  ...importConfig
+  //}
 ];

--- a/package.json
+++ b/package.json
@@ -44,21 +44,20 @@
   },
   "homepage": "https://github.com/digitalbazaar/eslint-config-digitalbazaar#readme",
   "dependencies": {
-    "@eslint/js": "^9.39.2",
-    "@stylistic/eslint-plugin": "^5.7.1",
-    "eslint-plugin-jsdoc": "^62.5.3",
-    "eslint-plugin-unicorn": "^62.0.0",
-    "eslint-plugin-vue": "^10.7.0",
-    "globals": "^17.3.0",
-    "vue-eslint-parser": "^10.2.0"
+    "@eslint/js": "^10.0.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
+    "eslint-plugin-jsdoc": "^63.0.5",
+    "eslint-plugin-unicorn": "^67.0.0",
+    "eslint-plugin-vue": "^10.9.2",
+    "globals": "^17.6.0",
+    "vue-eslint-parser": "^10.4.1"
   },
   "devDependencies": {
-    "eslint": "^9.39.2",
-    "eslint-plugin-eslint-plugin": "^7.3.0",
-    "eslint-plugin-import": "^2.32.0",
-    "vitest": "^4.0.18"
+    "eslint": "^10.5.0",
+    "eslint-plugin-eslint-plugin": "^7.4.0",
+    "vitest": "^4.1.9"
   },
   "peerDependencies": {
-    "eslint": "^9.39.2"
+    "eslint": "^10.5.0"
   }
 }

--- a/rules/catch-spacing.js
+++ b/rules/catch-spacing.js
@@ -10,7 +10,7 @@ export default {
   },
 
   create(context) {
-    const sourceCode = context.getSourceCode();
+    const {sourceCode} = context;
 
     return {
       CatchClause(node) {
@@ -23,7 +23,7 @@ export default {
 
         // case: catch(e)
         if(node.param && nextToken.value === '(') {
-          if(sourceCode.isSpaceBetweenTokens(catchToken, nextToken)) {
+          if(sourceCode.isSpaceBetween(catchToken, nextToken)) {
             context.report({
               node,
               messageId: 'unexpectedSpace',
@@ -40,7 +40,7 @@ export default {
 
         // case: catch {}
         if(!node.param && nextToken.value === '{') {
-          if(!sourceCode.isSpaceBetweenTokens(catchToken, nextToken)) {
+          if(!sourceCode.isSpaceBetween(catchToken, nextToken)) {
             context.report({
               node,
               messageId: 'missingSpace',


### PR DESCRIPTION
- Disabling `eslint-plugin-import` support.  Will be re-enabled if/when that plugin supports eslint 10.
- Major release due to the above and potential new issues that can get flagged in eslint and the plugins.